### PR TITLE
Add sphinx_copybutton extension

### DIFF
--- a/synaptics_sphinx_theme/__init__.py
+++ b/synaptics_sphinx_theme/__init__.py
@@ -49,6 +49,12 @@ def setup(app):
     app.setup_extension('sphinxcontrib.plantuml')
     app.setup_extension('breathe')
     app.setup_extension('myst_parser')
+    app.setup_extension('sphinx_copybutton')
+
+    # Configure sphinx-copybutton so that when users copy code blocks,
+    # any leading shell prompt ('$ ') is automatically removed from the copied text.
+    app.config.copybutton_prompt_text = r"\$ "
+    app.config.copybutton_prompt_is_regexp = True
 
     # exclude README.rst from the build by default    
     app.config.exclude_patterns += ["README.rst", "README.md"]


### PR DESCRIPTION
- configure prompt text and regexp options in theme setup
- any leading shell prompt ('$ ') is automatically removed from the copied text.